### PR TITLE
Improve collapsed-domain indicator

### DIFF
--- a/src/components/BookmarkColorPicker.vue
+++ b/src/components/BookmarkColorPicker.vue
@@ -76,9 +76,9 @@
           location="bottom"
           offset="8"
         >
-          <template #activator="{ props }">
+          <template #activator="{ props: menuProps }">
             <div
-              v-bind="props"
+              v-bind="menuProps"
               class="color-option custom-picker"
               :class="{ active: isCustomColor }"
             >
@@ -126,8 +126,8 @@
               v-model="customColor"
               mode="hex"
               :modes="['hex']"
-              :width="mobile ? 300 : 500"
               show-swatches
+              :width="mobile ? 300 : 500"
             />
 
             <v-card-actions class="pa-0 pt-3">
@@ -190,7 +190,7 @@
 <script setup>
   import { computed, ref } from 'vue'
   import { useDisplay } from 'vuetify'
-  const { mobile } = useDisplay();
+  const { mobile } = useDisplay()
 
   const props = defineProps({
     modelValue: {

--- a/src/components/BookmarkTable.vue
+++ b/src/components/BookmarkTable.vue
@@ -115,9 +115,9 @@
                 <v-icon icon="mdi-dots-vertical" size="16" />
               </v-btn>
 
-              <v-menu location="bottom start" offset="8" activator="parent">
-    
-                <v-list density="compact" min-width="160" max-width="100%">
+              <v-menu activator="parent" location="bottom start" offset="8">
+
+                <v-list density="compact" max-width="100%" min-width="160">
                   <v-list-item
                     :prepend-avatar="item.favicon"
                     @click="openBookmark(item.url)"
@@ -666,7 +666,7 @@
         // Method 2: Force a complete re-sync by triggering the watchers
         nextTick(() => {
           // Create a deep clone to ensure Vue detects the change
-          const clonedOptions = JSON.parse(JSON.stringify(localServerOptions.value))
+          const clonedOptions = structuredClone(localServerOptions.value)
 
           // Temporarily disable the watcher to prevent loops
           isUpdatingFromComposable.value = true

--- a/src/components/BookmarkTableCollapseIndicators.vue
+++ b/src/components/BookmarkTableCollapseIndicators.vue
@@ -1,37 +1,80 @@
 <template>
   <div class="d-flex">
-    <div
-      v-for="domain in collapsedDomains"
-      :key="domain.name"
-      class="collapse-indicator"
-      :title="`Expand ${domain.count} collapsed links from ${domain.name}`"
-    >
-      <v-card
-        class="ma-2 pa-1 collapsed-domain-card"
-        color="surface-variant"
-        variant="outlined"
+    <!-- Single collapsed domain: show direct card -->
+    <template v-if="collapsedDomains.length === 1">
+      <div
+        v-for="domain in collapsedDomains"
+        :key="domain.name"
+        class="collapse-indicator"
+        :title="`Expand ${domain.count} collapsed links from ${domain.name}`"
       >
-        <div
-          class="d-flex align-center justify-space-between cursor-pointer"
-          :class="{ 'loading': expandingDomain === domain.name }"
-          @click="$emit('expand-domain', domain.name)"
+        <v-card
+          class="ma-2 pa-1 collapsed-domain-card"
+          color="surface-variant"
+          variant="outlined"
         >
-          <div class="d-flex align-center">
-            <v-icon class="mr-2" color="primary" icon="mdi-arrow-expand-vertical" />
-            <div>
-              <div class="text-subtitle-2 font-weight-medium collapsed-domain-text">
-                {{ domain.count }} &times; {{ domain.name }}
+          <div
+            class="d-flex align-center justify-space-between cursor-pointer"
+            :class="{ 'loading': expandingDomain === domain.name }"
+            @click="$emit('expand-domain', domain.name)"
+          >
+            <div class="d-flex align-center">
+              <v-icon class="mr-2" color="primary" icon="mdi-arrow-expand-vertical" />
+              <div>
+                <div class="text-subtitle-2 font-weight-medium collapsed-domain-text">
+                  {{ domain.count }} &times; {{ domain.name }}
+                </div>
               </div>
             </div>
           </div>
-        </div>
-      </v-card>
-    </div>
+        </v-card>
+      </div>
+    </template>
+
+    <!-- Multiple collapsed domains: aggregated menu -->
+    <template v-else>
+      <v-menu offset="8">
+        <template #activator="{ props: menuProps }">
+          <div
+            class="collapse-indicator"
+            :title="`${totalCollapsedCount} collapsed links`"
+          >
+            <v-card
+              class="ma-2 pa-1 collapsed-domain-card cursor-pointer"
+              color="surface-variant"
+              variant="outlined"
+              v-bind="menuProps"
+            >
+              <div class="d-flex align-center">
+                <v-icon class="mr-2" color="primary" icon="mdi-arrow-expand-vertical" />
+                <div class="text-subtitle-2 font-weight-medium collapsed-domain-text">
+                  {{ totalCollapsedCount }} collapsed links
+                </div>
+              </div>
+            </v-card>
+          </div>
+        </template>
+
+        <v-list density="compact">
+          <v-list-item
+            v-for="domain in collapsedDomains"
+            :key="domain.name"
+            :class="{ 'loading': expandingDomain === domain.name }"
+            @click="$emit('expand-domain', domain.name)"
+          >
+            <v-list-item-title>
+              {{ domain.count }} &times; {{ domain.name }}
+            </v-list-item-title>
+          </v-list-item>
+        </v-list>
+      </v-menu>
+    </template>
   </div>
 </template>
 
 <script setup>
-  defineProps({
+  import { computed } from 'vue'
+  const props = defineProps({
     collapsedDomains: {
       type: Array,
       default: () => [],
@@ -43,6 +86,10 @@
   })
 
   defineEmits(['expand-domain'])
+
+  const totalCollapsedCount = computed(() =>
+    props.collapsedDomains.reduce((sum, d) => sum + d.count, 0),
+  )
 </script>
 
 <style scoped>

--- a/src/composables/useAverageColor.js
+++ b/src/composables/useAverageColor.js
@@ -33,7 +33,7 @@ export async function averageColor (srcOrImgElement) {
         resolve([128, 128, 128]) // fallback grey
       }
     })
-    img.onerror = () => resolve([128, 128, 128]) // fallback grey
+    img.addEventListener('error', () => resolve([128, 128, 128])) // fallback grey
     if (typeof srcOrImgElement !== 'string' && img.complete) {
       img.onload() // trigger if already loaded
     }

--- a/src/pages/import.vue
+++ b/src/pages/import.vue
@@ -392,7 +392,7 @@
     return new Promise((resolve, reject) => {
       const reader = new FileReader()
       reader.addEventListener('load', e => resolve(e.target.result))
-      reader.onerror = e => reject(e)
+      reader.addEventListener('error', e => reject(e))
       reader.text(file)
     })
   }

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -8,6 +8,7 @@ import { setupLayouts } from 'virtual:generated-layouts'
 // Composables
 // eslint-disable-next-line import/no-duplicates
 import { createRouter, createWebHistory } from 'vue-router/auto'
+// eslint-disable-next-line import/no-duplicates
 import { routes } from 'vue-router/auto-routes'
 
 const router = createRouter({


### PR DESCRIPTION
## Summary
- aggregate domain collapse buttons when multiple domains are collapsed
- adapt BookmarkColorPicker slot prop name to avoid lint error
- use `structuredClone` in BookmarkTable
- add error event listener for averageColor and import page
- silence duplicate import warning in router

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687d4101ef3c832f83d98623f10cc33a